### PR TITLE
change in the virtual environment doc

### DIFF
--- a/docs/defining_environment_from_komodo.md
+++ b/docs/defining_environment_from_komodo.md
@@ -4,8 +4,8 @@ Information can be found on <br>
 https://github.com/equinor/komodoenv
 
 1. Source Komodo environment<br>
-`source /prog/res/komodo/stable/enable`
-2. Create a personnal duplicate of the environment<br>
+`source /prog/res/komodo/stable/enable.csh`
+2. Create a personnal duplicate of the environment (it does not have to be named my-kenv)<br>
 `komodoenv my-kenv`
 3. source the new environment<br>
 `source my-kenv/enable.csh`   (my-kenv/enable, depending on your configuration)
@@ -13,11 +13,11 @@ https://github.com/equinor/komodoenv
 `pip install geostatspy`
 
 Next step is to install the new environment in a python kernel<br>
-`python -m ipykernel install --user --name=geostats-kenv --display-name="Python (geostats-kenv)"`
+`python -m ipykernel install --user --name=my-kenv --display-name="Python (geostats-kenv)"`
 
 NB: be aware that update of your environment is not automatic and it should be frequently updated (especially with new komodo release) by<br>
 `komodoenv-update`
-
+NB2: each new terminal windows will start with the default komodo. You will have to source your own vitual environment.
 
 
 # Using that new environment 
@@ -26,9 +26,9 @@ We will use GeostatGuy notebook for that
 `mkdir GeostatGuy`
 2. cloning the original notebook <br>
 `cd GeostatGuy` <br>
-`Git clone https://github.com/GeostatsGuy/GeostatsPyDemos_Book.git`
+`git clone https://github.com/GeostatsGuy/GeostatsPyDemos_Book.git`
 3. start Jupiter-lab and be ready to ~~cry~~ play<br>
-`Jupiter-lab`
+`jupyter-lab`
 4. Select the kernel <br> 
 kernel>Change_kernel <br>
 select the newly created one.


### PR DESCRIPTION
spelling correction for 
 - Git -> git
 - jupiter ->jupyter
 - python kernel command with the name of the created virtual environment